### PR TITLE
Update Cake Wallet Guides

### DIFF
--- a/docs/advanced-features/special-address-services.md
+++ b/docs/advanced-features/special-address-services.md
@@ -52,16 +52,13 @@ If (and only if) you type in an emoji, then your wallet will communicate directl
 
 ## Mastodon
 
-Cake Wallet allows you to type in a Mastodon username (eg: `@cakewallet@mastodon.sdf.org`) in the `Send` screen. If that user has a correctly-formatted address in their Mastodon bio or pinned post for the relevant cryptocurrency, then the wallet will display that address. If this process does not work, make sure the address in the bio is valid and the correct length.
+Cake Wallet allows you to type in a Mastodon username (eg: `@cakewallet@mstdn.plus`) in the `Send` screen. If that user has a correctly-formatted address in their Mastodon bio or pinned post for the relevant cryptocurrency, then the wallet will display that address. If this process does not work, make sure the address in the bio is valid and the correct length.
 
 If (and only if) you type in a Mastodon username, then your wallet will communicate directly with the specified Mastodon server's API.
 
 ## Twitter Bird Pay
 
-{: .warning}
-Twitter Bird Pay is currently not available due to issues with Twitter's API.
-
-Cake Wallet allows you to type in a Twitter username (eg: `@monerocom`) in the `Send` screen. If that user has a correctly-formatted address in their Twitter bio or pinned Tweet for the relevant cryptocurrency, then the wallet will display that address. If this process does not work, make sure the address in the bio is valid and the correct length.
+Cake Wallet allows you to type in a Twitter username (eg: `@cakewallet`) in the `Send` screen. If that user has a correctly-formatted address in their Twitter bio or pinned Tweet for the relevant cryptocurrency, then the wallet will display that address. If this process does not work, make sure the address in the bio is valid and the correct length.
 
 If (and only if) you type in a Twitter username, then your wallet will communicate directly with the Twitter API.
 

--- a/docs/basic-features/create-first-wallet.md
+++ b/docs/basic-features/create-first-wallet.md
@@ -12,11 +12,12 @@ We want to welcome you to using Cake Wallet! We hope you have a wonderful experi
 
 You first need the Cake Wallet official application.
 
-* Apple App Store (iPhone, MacOS): [https://cakewallet.com/ios](https://cakewallet.com/ios)
-* Google Play: [https://cakewallet.com/gp](https://cakewallet.com/gp)
-* F-Droid: [https://fdroid.cakelabs.com](https://fdroid.cakelabs.com)
-* Android APK: [https://cakewallet.com/apk](https://cakewallet.com/apk)
-* Linux: [https://github.com/cake-tech/cake_wallet/releases](https://github.com/cake-tech/cake_wallet/releases)
+* [Apple App Store (iPhone, MacOS)](https://apps.apple.com/us/app/cake-wallet-for-xmr-monero/id1334702542)
+* [Google Play](https://play.google.com/store/apps/details?id=com.cakewallet.cake_wallet&referrer=utm_source%3Dguides.cakewallet.com%26utm_medium%3Dwebsite)
+* [Accrescent](https://accrescent.app/app/com.cakewallet.cake_wallet)
+* [Android APK](https://github.com/cake-tech/cake_wallet/releases)
+* [Linux](https://github.com/cake-tech/cake_wallet/releases)
+* [Windows](https://github.com/cake-tech/cake_wallet/releases)
 
 ## Initial app configuration
 
@@ -54,4 +55,4 @@ Here is a list of a few known-good password managers. Open-source ones are recom
 | KeepassXC | Desktop | Local 💾 | GPLv3 ✅ |
 | KeepassDX | Android | Local 💾 | GPLv3 ✅ |
 | 1Password| Desktop | Cloud ☁️ | Proprietary ☢️ |
-| iCloud Keychain | Apple Only | Cloud ☁️ | Proprietary ☢️ |
+| iCloud Passwords | Desktop, iOS | Cloud ☁️ | Proprietary ☢️ |

--- a/docs/basic-features/exchange.md
+++ b/docs/basic-features/exchange.md
@@ -103,7 +103,7 @@ Cake Wallet's exchange providers support dozens of different cryptocurrency pair
 | USDT | Tether | ETH, OMNI, TRX |
 | WBTC | Wrapped Bitcoin | ETH |
 | WETH | Wrapped Ethereum | ETH |
-| XHV | Haven | Native |
+| XHV | Haven | Native | Project Shut Down |
 | XLM | Stellar Lumens | Native | Convert from only |
 | XMR | Monero | Native |
 | XRP | Ripple | Native | Convert from only |

--- a/docs/basic-features/receive-funds.md
+++ b/docs/basic-features/receive-funds.md
@@ -5,7 +5,7 @@ parent: Basic Features
 
 # Receive funds
 
-## Receiving Monero or Haven
+## Receiving Monero
 
 ### Current wallet address
 

--- a/docs/basic-features/restore-wallet-from-hardware.md
+++ b/docs/basic-features/restore-wallet-from-hardware.md
@@ -6,8 +6,7 @@ parent: Basic Features
 # Restore account from hardware wallet
 
 {: .note}
-Currently, we only support restoring from Ledger devices, with support for more devices coming soon.
-Only Bitcoin, Ethereum, and Polygon are currently supported.
+Currently, we only support restoring from Ledger devices, with support for more devices coming soon. We support restoring Bitcoin, Ethereum, Polygon, Litecoin, & Monero.
 
 ## Step 1
 

--- a/docs/basic-features/restore-wallet-from-keys-or-seed.md
+++ b/docs/basic-features/restore-wallet-from-keys-or-seed.md
@@ -25,7 +25,7 @@ Tap `Restore from seed/keys`, then choose the wallet type.
 
 ## Step 3
 
-If you choose Monero, Ethereum, Nano, or Haven, you can restore your wallet from the seed phrase or keys.
+If you choose Monero, Ethereum, or Nano you can restore your wallet from the seed phrase or keys.
 
 To swap from `Restore from seed` to `Restore from keys`, swipe the screen left to right.
 

--- a/docs/install/obtanium.md
+++ b/docs/install/obtanium.md
@@ -19,15 +19,15 @@ Once Obtanium is installed, you are able to add Cake Wallet via our repo.
 
 After opening Obtanium, press the `Add App` button on the bottom bar. Then, paste the Cake Wallet repository URL [https://github.com/cake-tech/cake_wallet/](https://github.com/cake-tech/cake_wallet/) into the `App Source URL` field, then press the `Add` button.
 
-![1](./obtanium-1.png){:width="32%"}
-![2](./obtanium-2.png){:width="32%"}
+![1](obtanium-1.png){:width="32%"}
+![2](obtanium-2.png){:width="32%"}
 
 Select Cake Wallet or Monero.com wallet then press `Continue`.
 
-![3](./obtanium-3.png){:width="32%"}
-![4](./obtanium-4.png){:width="32%"}
+![3](obtanium-3.png){:width="32%"}
+![4](obtanium-4.png){:width="32%"}
 
 Then press `Install` at the bottom of the app listing, and select the desired version once again if prompted.
 
-![5](./obtanium-5.png){:width="32%"}
-![6](./obtanium-6.png){:width="32%"}
+![5](obtanium-5.png){:width="32%"}
+![6](obtanium-6.png){:width="32%"}

--- a/docs/service-support/service-support.md
+++ b/docs/service-support/service-support.md
@@ -8,4 +8,4 @@ nav_order: 6
 
 Cake Wallet includes third-party services to enrich your experience. Please click on the applicable feature to get support.
 
-When in doubt, you can always message Cake Wallet support [by email](mailto:support@cakewallet.com) or [on Telegram](https://t.me/cakewallet_bot).
+When in doubt, you can always message Cake Wallet support in-app, [by email](mailto:support@cakewallet.com) or [on Telegram](https://t.me/cakewallet_bot).

--- a/index.md
+++ b/index.md
@@ -16,11 +16,10 @@ Thanks for using Cake Wallet! Cake Wallet is open source with a permissive MIT l
 
 The Cake Wallet support staff want to make sure that you have an excellent user experience. We have staff working around the clock to respond to questions.
 
-Here you can find answers to the most common questions about Cake Wallet. If you don't find an answer to your question, **contact us by clicking the support icon in the lower right of this page, or contacting us directly in the app under Support**. Alternatively, you can contact us using email **support@cakewallet.com**, [**Telegram**](https://t.me/cakewallet_bot), or [**Twitter**](https://twitter.com/cakewallet).
+Here you can find answers to the most common questions about Cake Wallet. If you don't find an answer to your question, **contact us by clicking the support icon in the lower right of this page, or contacting us directly in the app under Support**. Alternatively, you can contact us using email **support@cakewallet.com**, or [**Telegram**](https://t.me/cakewallet_bot).
 
 [Email support](mailto:support@cakewallet.com){: .btn .btn-blue .mr-4 }
 [Telegram support](https://t.me/cakewallet_bot){: .btn .btn-blue .mr-4 }
-[Twitter support](https://twitter.com/cakewallet){: .btn .btn-blue }
 
 ## General info
 
@@ -34,7 +33,7 @@ Don't have Cake Wallet yet? Download it today!
 
 [iOS / MacOS](https://apps.apple.com/us/app/cake-wallet-for-xmr-monero/id1334702542){: .btn .btn-blue .mr-2 }
 [Google Play](https://play.google.com/store/apps/details?id=com.cakewallet.cake_wallet&referrer=utm_source%3Dguides.cakewallet.com%26utm_medium%3Dwebsite){: .btn .btn-blue .mr-2 }
-[F-Droid](https://fdroid.cakelabs.com){: .btn .btn-blue .mr-2 }
+[Accrescent](https://accrescent.app/app/com.cakewallet.cake_wallet){: .btn .btn-blue .mr-2 }
 [Android APK](https://github.com/cake-tech/cake_wallet/releases){: .btn .btn-blue .mr-2 }
 [Linux](https://github.com/cake-tech/cake_wallet/releases){: .btn .btn-blue .mr-2 }
 [Windows](https://github.com/cake-tech/cake_wallet/releases){: .btn .btn-blue }
@@ -53,4 +52,13 @@ Cake Wallet is available on both Apple Silicon (eg: M1/M2) and Intel Macs.
 
 ## Cake Wallet service status
 
-[**https://status.cakewallet.com**](https://status.cakewallet.com)
+[https://status.cakewallet.com](https://status.cakewallet.com)
+
+## Follow Cake Wallet
+
+Want to follow our work more closely? Join our main communities & socials:
+
+[Blog](https://cakelabs.com/news/index.html){: .btn .btn-blue .mr-2 }
+[X/Twitter](https://x.com/cakewallet){: .btn .btn-blue .mr-2 }
+[Forum](https://forum.cakewallet.com){: .btn .btn-blue .mr-2 }
+[Telegram](t.me/cakewalletannouncements){: .btn .btn-blue .mr-2 }


### PR DESCRIPTION
- Remove Twitter support on index
- Attempted fix for Obtanium screenshots broken in installation
- Update install URLs in create-first-wallet
- Replace F-Droid with Accrescent
- Add core Cake Wallet socials on index
- Update iCloud Passwords with newer information now it's more cross-platform
- Remove rogue mentions of Haven
- Add Ledger support for Litecoin & Monero
- Remove Twitter bird pay warning as Twitter bird pay is functioning & active
- Update Mastodon handle to reflect Cake Wallet's actual handle